### PR TITLE
Fixes problem with param_r

### DIFF
--- a/cfhb.py
+++ b/cfhb.py
@@ -5,7 +5,8 @@ import re, json
 
 
 class Cloudflare:
-    def __init__(self, session: Session, host: str, default_page: str):
+    def __init__(self, session: Session, host: str, default_page: str, param_r: str):
+        self.param_r = param_r
         self.session = session
         self.host = host
         self.default_page = default_page
@@ -22,8 +23,6 @@ class Cloudflare:
         Solve the Cloudflare /h/b challenge and returns the cookie
         :return: cf_clearance cookie
         """
-        param_r = re.findall(r"r:'(.+?)'", self.default_page)
-
         script = self.session.get(f"https://{self.host}/cdn-cgi/challenge-platform/scripts/jsd/main.js").text
 
         key = next((i for i in script.split(",") if
@@ -32,7 +31,7 @@ class Cloudflare:
 
         compressed_fingerprint = LZString.compressToCustom(self.get_fingerprint(fp), key)
 
-        res = self.session.post(f"https://{self.host}/cdn-cgi/challenge-platform/h/b{path}{param_r}",
-                                data=compressed_fingerprint)
+        url = f"https://{self.host}/cdn-cgi/challenge-platform/h/b{path}{self.param_r}"
+        res = self.session.post(url, data=compressed_fingerprint)
 
         return res.cookies.get("cf_clearance")

--- a/example.py
+++ b/example.py
@@ -6,9 +6,9 @@ from cfhb import Cloudflare
 session = Session()
 session.headers = {
     "connection": "keep-alive",
-    "sec-ch-ua-platform": "\"Windows\"",
+    "sec-ch-ua-platform": '"Windows"',
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
-    "sec-ch-ua": "\"Not A(Brand\";v=\"8\", \"Chromium\";v=\"132\", \"Google Chrome\";v=\"132\"",
+    "sec-ch-ua": '"Not A(Brand";v="8", "Chromium";v="132", "Google Chrome";v="132"',
     "sec-ch-ua-mobile": "?0",
     "sec-fetch-site": "same-origin",
     "sec-fetch-mode": "no-cors",
@@ -17,10 +17,13 @@ session.headers = {
     "accept-language": "en-US,en;q=0.9",
 }
 
-init_res = session.get("https://www.bstn.com/eu_de").text
+response = session.get("https://www.bstn.com/eu_de")
+init_res = response.text
+
+param_r = init_res.headers["cf-ray"].split("-")[0]
 # do something with the initial request...
 
-cf_clearance = (Cloudflare(session, "www.bstn.com", init_res).solve())
+cf_clearance = Cloudflare(session, "www.bstn.com", init_res, param_r).solve()
 
 print("[+]", cf_clearance, len(cf_clearance))
 print(session.cookies.get_dict())

--- a/example.py
+++ b/example.py
@@ -20,7 +20,7 @@ session.headers = {
 response = session.get("https://www.bstn.com/eu_de")
 init_res = response.text
 
-param_r = init_res.headers["cf-ray"].split("-")[0]
+param_r = response.headers["cf-ray"].split("-")[0]
 # do something with the initial request...
 
 cf_clearance = Cloudflare(session, "www.bstn.com", init_res, param_r).solve()

--- a/readme.md
+++ b/readme.md
@@ -2,22 +2,27 @@
 
 I fully reverse engineered the `/cdn-cgi/challenge-platform/h/b/jsd` [challenge](./reverse/script.js).
 
-
 # ⭐️ star the repo
+
 please star the repo to show support❤️
 i might publish cf turnstile👀
+
 ## Installation
+
 ```
 Copy cfhb.py & lzstring.py into your project and import Cloudflare from cfbm
 ```
 
 ## Fingerprint
+
 Obtaining a fingerprint is pretty easy.
+
 1. Go to the target Website
 2. Copy the code from [get_fingerprint.js](get_fingerprint.js) and paste it into the console (F12 -> Console)
 3. Copy the output and paste it into `fingerprint.json`
 
 The script automatically gets the fingerprint and replaces the timestamp with %timestamp% for your convenience
+
 ## Example Usage
 
 ```python
@@ -29,9 +34,9 @@ from cfhb import Cloudflare
 session = Session()
 session.headers = {
     "connection": "keep-alive",
-    "sec-ch-ua-platform": "\"Windows\"",
+    "sec-ch-ua-platform": '"Windows"',
     "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/132.0.0.0 Safari/537.36",
-    "sec-ch-ua": "\"Not A(Brand\";v=\"8\", \"Chromium\";v=\"132\", \"Google Chrome\";v=\"132\"",
+    "sec-ch-ua": '"Not A(Brand";v="8", "Chromium";v="132", "Google Chrome";v="132"',
     "sec-ch-ua-mobile": "?0",
     "sec-fetch-site": "same-origin",
     "sec-fetch-mode": "no-cors",
@@ -40,13 +45,17 @@ session.headers = {
     "accept-language": "en-US,en;q=0.9",
 }
 
-init_res = session.get("https://www.bstn.com/eu_de").text
+response = session.get("https://www.bstn.com/eu_de")
+init_res = response.text
+
+param_r = init_res.headers["cf-ray"].split("-")[0]
 # do something with the initial request...
 
-cf_clearance = (Cloudflare(session, "www.bstn.com", init_res).solve())
+cf_clearance = Cloudflare(session, "www.bstn.com", init_res, param_r).solve()
 
 print("[+]", cf_clearance, len(cf_clearance))
 print(session.cookies.get_dict())
+
 # execution time: ~700ms
 ```
 
@@ -67,6 +76,5 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 ## Disclaimer
 
 This package is unofficial and not affiliated with Cloudflare. Use it responsibly and in accordance with Cloudflare's terms of service.
-
 
 > I might share how I managed to reverse engineer the challenge if this repository receives enough attention.

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ session.headers = {
 response = session.get("https://www.bstn.com/eu_de")
 init_res = response.text
 
-param_r = init_res.headers["cf-ray"].split("-")[0]
+param_r = response.headers["cf-ray"].split("-")[0]
 # do something with the initial request...
 
 cf_clearance = Cloudflare(session, "www.bstn.com", init_res, param_r).solve()


### PR DESCRIPTION
![telegram-cloud-photo-size-2-5282824304410617180-y](https://github.com/user-attachments/assets/a7d204e1-7974-4d35-9f4b-476cd2cc53fd)
![telegram-cloud-photo-size-2-5282729072100767119-y](https://github.com/user-attachments/assets/b3681d07-aea6-4309-b51f-5c838ab9b993)
There was a problem getting param_r
The old method didn't get param_r and instead of it was just an empty list

Fixed it by getting cf-ray from headers

```py
response = session.get("https://www.bstn.com/eu_de")
param_r = init_res.headers["cf-ray"].split("-")[0]
```
